### PR TITLE
Add Database Connectivity for JWT Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# JWT Authentication with Spring Security 🌐🔐
+
+Welcome to the **JWT Spring Security** repository! 🚀
+
+This project demonstrates how to implement **JSON Web Token (JWT)** authentication and authorization using **Spring Security** in a Java-based application. It provides a secure and scalable way to manage access control in modern web applications. ⚙️🔑
+
+---
+
+## Features ✨
+
+- **JWT Authentication**: Securely authenticate users with JWT tokens. 🛡️
+- **Spring Security Integration**: Seamlessly integrates JWT with Spring Security for enhanced security. 🔒
+- **Scalable Authorization**: Easily extend the application to add more roles and permissions. 📈
+- **Maven Build**: Simple setup and configuration with Maven. 🏗️
+
+---
+
+## Project Setup 🖥️
+
+To run this project locally, follow these steps:
+
+1. **Clone the repository**:  
+   Clone this repository to your local machine using Git.
+   ```bash
+   git clone https://github.com/Chathupachamika/JWT_Spring_Secuirity.git

--- a/pom.xml
+++ b/pom.xml
@@ -58,10 +58,10 @@
 			<scope>runtime</scope>
 		</dependency>
 
-<!--		<dependency>-->
-<!--			<groupId>org.springframework.boot</groupId>-->
-<!--			<artifactId>spring-boot-starter-data-jpa</artifactId>-->
-<!--		</dependency>-->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>42.7.2</version>
+			<version>42.6.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,33 @@
 			<version>1.18.30</version>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.12.6</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.12.6</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.12.6</version>
+			<scope>runtime</scope>
+		</dependency>
 
+<!--		<dependency>-->
+<!--			<groupId>org.springframework.boot</groupId>-->
+<!--			<artifactId>spring-boot-starter-data-jpa</artifactId>-->
+<!--		</dependency>-->
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>42.7.2</version>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>

--- a/src/main/java/com/jwt/SpringSecEx/config/SecurityConfig.java
+++ b/src/main/java/com/jwt/SpringSecEx/config/SecurityConfig.java
@@ -29,12 +29,25 @@ public class SecurityConfig {
 //        http.formLogin(Customizer.withDefaults());
     }
 
-    @Bean
-    public UserDetailsService userDetailsService(){
 
-        UserDetails userDetails = User
-                .
-
-        return new InMemoryUserDetailsManager();
-    }
+//    @Bean
+//    public UserDetailsService userDetailsService(){
+//
+//        UserDetails user1 = User
+//                .withDefaultPasswordEncoder()
+//                .username("chathupa")
+//                .password("k@123")
+//                .roles("USER")
+//                .build();
+//
+//        UserDetails user2 = User
+//                .withDefaultPasswordEncoder()
+//                .username("saman")
+//                .password("k@123")
+//                .roles("ADMIN")
+//                .build();
+//
+//
+//        return new InMemoryUserDetailsManager(user1,user2);
+//    }
 }

--- a/src/main/java/com/jwt/SpringSecEx/config/SecurityConfig.java
+++ b/src/main/java/com/jwt/SpringSecEx/config/SecurityConfig.java
@@ -32,7 +32,10 @@ public class SecurityConfig {
 
           return http
                   .csrf(customzer -> customzer.disable())
-                  .authorizeHttpRequests(request -> request.anyRequest().authenticated())
+                  .authorizeHttpRequests(request -> request
+                          .requestMatchers("register", "login")
+                          .permitAll()
+                          .anyRequest().authenticated())
                   .httpBasic(Customizer.withDefaults())
                   .sessionManagement(session-> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                   .build();
@@ -48,6 +51,10 @@ public class SecurityConfig {
         return provider;
     }
 
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
 //    @Bean
 //    public UserDetailsService userDetailsService(){
 //
@@ -69,8 +76,4 @@ public class SecurityConfig {
 //        return new InMemoryUserDetailsManager(user1,user2);
 //    }
 
-    @Bean
-    public AuthenticationManager authenticationManager (AuthenticationConfiguration config) throws Exception {
-        return config.getAuthenticationManager();
-    }
 }

--- a/src/main/java/com/jwt/SpringSecEx/config/SecurityConfig.java
+++ b/src/main/java/com/jwt/SpringSecEx/config/SecurityConfig.java
@@ -1,8 +1,13 @@
 package com.jwt.SpringSecEx.config;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
@@ -10,12 +15,16 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+
+    @Autowired
+    private UserDetailsService userDetailsService;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -29,6 +38,14 @@ public class SecurityConfig {
 //        http.formLogin(Customizer.withDefaults());
     }
 
+
+    @Bean
+    public AuthenticationProvider authenticationProvider(){
+        DaoAuthenticationProvider provider= new DaoAuthenticationProvider();
+        provider.setPasswordEncoder(NoOpPasswordEncoder.getInstance());
+        provider.setUserDetailsService(userDetailsService);
+        return provider;
+    }
 
 //    @Bean
 //    public UserDetailsService userDetailsService(){
@@ -50,4 +67,9 @@ public class SecurityConfig {
 //
 //        return new InMemoryUserDetailsManager(user1,user2);
 //    }
+
+    @Bean
+    public AuthenticationManager authenticationManager (AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
 }

--- a/src/main/java/com/jwt/SpringSecEx/config/SecurityConfig.java
+++ b/src/main/java/com/jwt/SpringSecEx/config/SecurityConfig.java
@@ -15,6 +15,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
@@ -42,7 +43,7 @@ public class SecurityConfig {
     @Bean
     public AuthenticationProvider authenticationProvider(){
         DaoAuthenticationProvider provider= new DaoAuthenticationProvider();
-        provider.setPasswordEncoder(NoOpPasswordEncoder.getInstance());
+        provider.setPasswordEncoder(new BCryptPasswordEncoder(12));
         provider.setUserDetailsService(userDetailsService);
         return provider;
     }

--- a/src/main/java/com/jwt/SpringSecEx/config/SecurityConfig.java
+++ b/src/main/java/com/jwt/SpringSecEx/config/SecurityConfig.java
@@ -2,8 +2,15 @@ package com.jwt.SpringSecEx.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -13,7 +20,21 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 
-        http.csrf(customzer -> customzer.disable());
-        return http.build();
+          return http
+                  .csrf(customzer -> customzer.disable())
+                  .authorizeHttpRequests(request -> request.anyRequest().authenticated())
+                  .httpBasic(Customizer.withDefaults())
+                  .sessionManagement(session-> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                  .build();
+//        http.formLogin(Customizer.withDefaults());
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService(){
+
+        UserDetails userDetails = User
+                .
+
+        return new InMemoryUserDetailsManager();
     }
 }

--- a/src/main/java/com/jwt/SpringSecEx/controller/HelloController.java
+++ b/src/main/java/com/jwt/SpringSecEx/controller/HelloController.java
@@ -1,4 +1,4 @@
-package com.jwt.SpringSecEx;
+package com.jwt.SpringSecEx.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/com/jwt/SpringSecEx/controller/StudentController.java
+++ b/src/main/java/com/jwt/SpringSecEx/controller/StudentController.java
@@ -1,5 +1,6 @@
-package com.jwt.SpringSecEx;
+package com.jwt.SpringSecEx.controller;
 
+import com.jwt.SpringSecEx.model.Student;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/com/jwt/SpringSecEx/controller/UserController.java
+++ b/src/main/java/com/jwt/SpringSecEx/controller/UserController.java
@@ -1,0 +1,25 @@
+package com.jwt.SpringSecEx.controller;
+
+import com.jwt.SpringSecEx.model.Users;
+import com.jwt.SpringSecEx.service.UserSerivce;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class UserController {
+
+    @Autowired
+    private UserSerivce service;
+
+    @PostMapping("/register")
+    public Users register(@RequestBody Users user){
+        return service.register(user);
+    }
+
+    @PostMapping("/login")
+    public String login(@RequestBody Users user){
+        return "Success";
+    }
+}

--- a/src/main/java/com/jwt/SpringSecEx/controller/UserController.java
+++ b/src/main/java/com/jwt/SpringSecEx/controller/UserController.java
@@ -20,6 +20,6 @@ public class UserController {
 
     @PostMapping("/login")
     public String login(@RequestBody Users user){
-        return "Success";
+        return service.verify(user);
     }
 }

--- a/src/main/java/com/jwt/SpringSecEx/model/Student.java
+++ b/src/main/java/com/jwt/SpringSecEx/model/Student.java
@@ -1,4 +1,4 @@
-package com.jwt.SpringSecEx;
+package com.jwt.SpringSecEx.model;
 
 import lombok.*;
 

--- a/src/main/java/com/jwt/SpringSecEx/model/UserPrincipal.java
+++ b/src/main/java/com/jwt/SpringSecEx/model/UserPrincipal.java
@@ -1,0 +1,56 @@
+package com.jwt.SpringSecEx.model;
+
+import lombok.*;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Setter
+@Getter
+public class UserPrincipal implements UserDetails {
+
+    private Users user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(new SimpleGrantedAuthority("USER"));
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUsername();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/jwt/SpringSecEx/model/Users.java
+++ b/src/main/java/com/jwt/SpringSecEx/model/Users.java
@@ -1,7 +1,10 @@
 package com.jwt.SpringSecEx.model;
 
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
 import lombok.*;
+
 
 @Setter
 @Getter
@@ -9,7 +12,7 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
-@Ent
+@Entity
 public class Users {
     @Id
     private int id;

--- a/src/main/java/com/jwt/SpringSecEx/model/Users.java
+++ b/src/main/java/com/jwt/SpringSecEx/model/Users.java
@@ -1,0 +1,18 @@
+package com.jwt.SpringSecEx.model;
+
+
+import lombok.*;
+
+@Setter
+@Getter
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Ent
+public class Users {
+    @Id
+    private int id;
+    private String username;
+    private String password;
+}

--- a/src/main/java/com/jwt/SpringSecEx/repo/UserRepo.java
+++ b/src/main/java/com/jwt/SpringSecEx/repo/UserRepo.java
@@ -1,7 +1,12 @@
 package com.jwt.SpringSecEx.repo;
 
+
 import com.jwt.SpringSecEx.model.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface UserRepo extends JpaRepository <Users, Integer>{
+
+    Users findByUsername(String username);
 }

--- a/src/main/java/com/jwt/SpringSecEx/repo/UserRepo.java
+++ b/src/main/java/com/jwt/SpringSecEx/repo/UserRepo.java
@@ -1,0 +1,7 @@
+package com.jwt.SpringSecEx.repo;
+
+import com.jwt.SpringSecEx.model.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepo extends JpaRepository <Users, Integer>{
+}

--- a/src/main/java/com/jwt/SpringSecEx/service/JWTService.java
+++ b/src/main/java/com/jwt/SpringSecEx/service/JWTService.java
@@ -1,0 +1,10 @@
+package com.jwt.SpringSecEx.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class JWTService {
+    public String generateToken() {
+        return "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkNoYXRodXBhIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE1MTYyNDkwMjJ9.Se_I1HznsJzx0BFAdbZzFyUHT9QNpW4vp5QMgRZyWmk";
+    }
+}

--- a/src/main/java/com/jwt/SpringSecEx/service/JWTService.java
+++ b/src/main/java/com/jwt/SpringSecEx/service/JWTService.java
@@ -1,10 +1,17 @@
 package com.jwt.SpringSecEx.service;
 
+import io.jsonwebtoken.Jwts;
 import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Service
 public class JWTService {
     public String generateToken() {
+        Map<String, Object> claims= new HashMap<>();
+
+        return Jwts 
         return "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkNoYXRodXBhIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE1MTYyNDkwMjJ9.Se_I1HznsJzx0BFAdbZzFyUHT9QNpW4vp5QMgRZyWmk";
     }
 }

--- a/src/main/java/com/jwt/SpringSecEx/service/MyUserDetailsService.java
+++ b/src/main/java/com/jwt/SpringSecEx/service/MyUserDetailsService.java
@@ -1,0 +1,14 @@
+package com.jwt.SpringSecEx.service;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MyUserDetailsService implements UserDetailsService {
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return null;
+    }
+}

--- a/src/main/java/com/jwt/SpringSecEx/service/MyUserDetailsService.java
+++ b/src/main/java/com/jwt/SpringSecEx/service/MyUserDetailsService.java
@@ -1,5 +1,9 @@
 package com.jwt.SpringSecEx.service;
 
+import com.jwt.SpringSecEx.model.UserPrincipal;
+import com.jwt.SpringSecEx.model.Users;
+import com.jwt.SpringSecEx.repo.UserRepo;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -7,8 +11,19 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class MyUserDetailsService implements UserDetailsService {
+
+    @Autowired
+    private UserRepo repo;
+
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        return null;
+        Users user = repo.findByUsername(username);
+        if(user== null){
+            System.out.println("User not  Found");
+            throw new UsernameNotFoundException("user not found");
+        }
+
+
+        return new UserPrincipal(user);
     }
 }

--- a/src/main/java/com/jwt/SpringSecEx/service/UserSerivce.java
+++ b/src/main/java/com/jwt/SpringSecEx/service/UserSerivce.java
@@ -16,6 +16,7 @@ public class UserSerivce {
 
     public Users register(Users users){
         users.setPassword(encoder.encode(users.getPassword()));
+        users.setPassword(encoder.encode(users.getPassword()));
         return repo.save(users);
     }
 }

--- a/src/main/java/com/jwt/SpringSecEx/service/UserSerivce.java
+++ b/src/main/java/com/jwt/SpringSecEx/service/UserSerivce.java
@@ -3,6 +3,9 @@ package com.jwt.SpringSecEx.service;
 import com.jwt.SpringSecEx.model.Users;
 import com.jwt.SpringSecEx.repo.UserRepo;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -12,11 +15,26 @@ public class UserSerivce {
     @Autowired
     private UserRepo repo;
 
+    @Autowired
+    private JWTService jwtService;
+
+    @Autowired
+    AuthenticationManager authManager;
+
     private BCryptPasswordEncoder encoder = new BCryptPasswordEncoder(12);
 
     public Users register(Users users){
         users.setPassword(encoder.encode(users.getPassword()));
         users.setPassword(encoder.encode(users.getPassword()));
         return repo.save(users);
+    }
+
+    public String verify(Users user) {
+        Authentication authentication =
+                authManager.authenticate(new UsernamePasswordAuthenticationToken(user.getUsername(),user.getPassword()));
+
+        if(authentication.isAuthenticated())
+            return jwtService.generateToken();
+        return "fail";
     }
 }

--- a/src/main/java/com/jwt/SpringSecEx/service/UserSerivce.java
+++ b/src/main/java/com/jwt/SpringSecEx/service/UserSerivce.java
@@ -1,0 +1,21 @@
+package com.jwt.SpringSecEx.service;
+
+import com.jwt.SpringSecEx.model.Users;
+import com.jwt.SpringSecEx.repo.UserRepo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserSerivce {
+
+    @Autowired
+    private UserRepo repo;
+
+    private BCryptPasswordEncoder encoder = new BCryptPasswordEncoder(12);
+
+    public Users register(Users users){
+        users.setPassword(encoder.encode(users.getPassword()));
+        return repo.save(users);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,3 +2,7 @@ spring.application.name=SpringSecEx
 
 spring.security.user.name=chathupa
 spring.security.user.password=chamika
+
+spring.datasource.url=jdbc:postgresql://localhost:5432/springsecurity
+spring.datasource.username=postgres
+spring.datasource.password=1234


### PR DESCRIPTION
This pull request adds database connectivity to the JWT authentication system. It integrates the application with a relational database to manage user data securely and efficiently.

Key Changes:

Added database configuration in application.properties.
Implemented JPA repositories for user entity management.
Updated the service layer to interact with the database.
Why this is needed:

To store user information persistently.
To allow dynamic retrieval and management of user roles and tokens.
Testing Details:

Tested database connectivity with H2 (in-memory database) during development.
Verified CRUD operations for the user entity.
Steps to Test:

Clone the repository.
Configure the database connection in application.properties.
Run the application and perform user registration and login.